### PR TITLE
bump fitsio version to 1.1.2 to avoid problem reading some CP headers…

### DIFF
--- a/decals-web-spin/app/requirements.txt
+++ b/decals-web-spin/app/requirements.txt
@@ -10,7 +10,7 @@ decorator==4.4.0
 defusedxml==0.6.0
 Django>=2.2.3
 entrypoints==0.3
-fitsio==0.9.12
+fitsio==1.1.2
 importlib-metadata==0.17
 jedi==0.13.3
 Jinja2==2.10.1


### PR DESCRIPTION
… where the PLVER string gets parsed as a float (but fails)
eg https://www.legacysurvey.org/viewer/image-data/ls-dr8/mosaic-122699-CCD2

Hi Mark,
Would you mind rebuilding & pushing this container (bumping the tag version if you like).  No rush.
Thanks!
--dustin

